### PR TITLE
docs: fix the example for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fileSelector.addEventListener('change', function (e) {
 
     reader.onload = function (event) {
         const buffer = new Uint8Array(event.target.result);
-        const parser = new pickleparser.Parser();
+        const parser = new Parser();
         const obj = parser.parse(buffer);
         const json = JSON.stringify(obj, null, 4);
         jsonResultPreviewer.innerText = json;


### PR DESCRIPTION
we import explicitly "Parser" and shouldn't use libname

the new line on the end of README.md was added automatically as it's set [here](https://github.com/ewfian/pickleparser/blob/f571511d565eaf0316146ce7a7d0d7c718cb44ce/.editorconfig#L8)